### PR TITLE
fix: excluding node_modules and .env from commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+#Excluding all node_modules and .env at the whole project level
+**/.env
+**/node_modules/


### PR DESCRIPTION
## Description

The project does not have any .gitignore file, which will cause all node_modules as well as potential env files to be included inside of commits when you will run it (after installing dependencies and creating .env files).

## Related Issue

[[Link to the issue this PR addresses, if applicable]](https://github.com/portdeveloper/slot-machine-monorepo/issues/2)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Discord/Telegram handle

aurel_dev0x1 (Discord)
